### PR TITLE
centos7 requires openssl 1.0.2

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -279,7 +279,7 @@ docker-targets:
       libX11
       libXext
       libXrender
-      openssl
+      'openssl > 1.0.1'
       xorg-x11-fonts-75dpi
       xorg-x11-fonts-Type1
       zlib


### PR DESCRIPTION
I haven't tried to build a package with this dependency but I see that you use `fpm` and so this syntax should work.