### PR TITLE
POC alpine build from docker

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -16,6 +16,12 @@ qemu-cmd:      docker run --rm --privileged fkrull/qemu-user-static enable
 #   qemu:           set to true if qemu emulation is required (optional)
 #
 docker-targets:
+  alpine:
+    source: docker/Dockerfile.alpine
+    args:
+      from: alpine:3.7
+    output: tar
+
   stretch-amd64:
     source: docker/Dockerfile.debian
     args:

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,15 @@
+ARG  from
+FROM ${from}
+
+ENV  CFLAGS=-w CXXFLAGS=-w
+
+RUN apk add make
+RUN apk add perl
+RUN apk add g++
+RUN apk add libxext-dev
+RUN apk add libx11-dev
+RUN apk add libxrender-dev
+RUN apk add openssl-dev
+RUN apk add linux-headers
+RUN apk add libpng-dev
+RUN apk add libjpeg-turbo-dev


### PR DESCRIPTION
This is not working as expected yet.
Haven't found time recently to figure this out.

### Current situation:
Without explicitly apply any Qt patches, It looks like below, and it crashed while converting html to pdf
![image](https://user-images.githubusercontent.com/10416228/55858466-671d4a80-5b8d-11e9-90de-971ae372d3a0.png)

When I tried applying Qt patches from the below link, the above issue was solved but it was still crashing with segmentation fault
https://github.com/IcaliaLabs/docker-wkhtmltopdf/tree/master/conf
![image](https://user-images.githubusercontent.com/10416228/55858605-c2e7d380-5b8d-11e9-8d39-ed5ac091e177.png)

### Steps I followed to build wkhtmlto* for alpine
* Run `./build docker-images alpine` to build docker image
* ~Run `./build compile-docker --debug alpine ../wkhtmltopdf/ ../wkhtmltopdf-built/` to build wkhtmlto* binaries~
* Run `./build package-docker --clean alpine ../wkhtmltopdf/`