### PR TITLE
Add support for Debian Buster

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -16,6 +16,52 @@ qemu-cmd:      docker run --rm --privileged fkrull/qemu-user-static enable
 #   qemu:           set to true if qemu emulation is required (optional)
 #
 docker-targets:
+  buster-amd64:
+    source: docker/Dockerfile.debian
+    args:
+      from: debian:buster
+    output: deb
+    arch:   amd64
+    depend: >
+      ca-certificates
+      fontconfig
+      libc6
+      libfreetype6
+      libjpeg62-turbo
+      libpng16-16
+      libssl1.1
+      libstdc++6
+      libx11-6
+      libxcb1
+      libxext6
+      libxrender1
+      xfonts-75dpi
+      xfonts-base
+      zlib1g
+
+  buster-i386:
+    source: docker/Dockerfile.debian
+    args:
+      from: i386/debian:buster
+    output: deb
+    arch:   i386
+    depend: >
+      ca-certificates
+      fontconfig
+      libc6
+      libfreetype6
+      libjpeg62-turbo
+      libpng16-16
+      libssl1.1
+      libstdc++6
+      libx11-6
+      libxcb1
+      libxext6
+      libxrender1
+      xfonts-75dpi
+      xfonts-base
+      zlib1g
+
   stretch-amd64:
     source: docker/Dockerfile.debian
     args:


### PR DESCRIPTION
Debian Buster is to be released as stable on july 6th