### PR TITLE
add Ubuntu 20.04 build

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -132,6 +132,30 @@ docker-targets:
       xfonts-base
       zlib1g
 
+  focal-amd64:
+    source: docker/Dockerfile.focal
+    args:
+      from: ubuntu:focal
+      jpeg: libjpeg-turbo8-dev
+    output: deb
+    arch:   amd64
+    depend: >
+      ca-certificates
+      fontconfig
+      libc6
+      libfreetype6
+      libjpeg-turbo8
+      libpng16-16
+      libssl1.1
+      libstdc++6
+      libx11-6
+      libxcb1
+      libxext6
+      libxrender1
+      xfonts-75dpi
+      xfonts-base
+      zlib1g
+
   bionic-amd64:
     source: docker/Dockerfile.debian
     args:

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -23,4 +23,4 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/bin/gcc-7 /usr/bin/gcc; ln -s /usr/bin/gcc-ar-7 /usr/bin/gcc-ar; ln -s /usr/bin/gcc-nm-7 /usr/bin/gcc-nm; ln -s /usr/bin/gcc-ranlib-7 /usr/bin/gcc-ranlib; ln -s /usr/bin/gcov-7 /usr/bin/gcov; ln -s /usr/bin/gcov-dump-7 /usr/bin/gcov-dump; ln -s /usr/bin/gcov-tool-7 /usr/bin/gcov-tool; ln -s /usr/bin/g++-7 /usr/bin/g++; ln -s /usr/bin/cpp-7 /usr/bin/cpp
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 10 --slave /usr/bin/g++ g++ /usr/bin/g++-7 --slave /usr/bin/cpp cpp /usr/bin/cpp-7

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -1,0 +1,26 @@
+ARG  from
+FROM ${from}
+
+ARG  jpeg=libjpeg-dev
+ARG  ssl=libssl-dev
+ENV  CFLAGS=-w CXXFLAGS=-w
+
+RUN apt-get update && apt-get install -y -q --no-install-recommends \
+    dpkg-dev \
+    libc6-dev \
+    make \
+    gcc-7 \
+    g++-7 \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    $jpeg \
+    libpng-dev \
+    $ssl \
+    libx11-dev \
+    libxext-dev \
+    libxrender-dev \
+    python \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/gcc-7 /usr/bin/gcc; ln -s /usr/bin/gcc-ar-7 /usr/bin/gcc-ar; ln -s /usr/bin/gcc-nm-7 /usr/bin/gcc-nm; ln -s /usr/bin/gcc-ranlib-7 /usr/bin/gcc-ranlib; ln -s /usr/bin/gcov-7 /usr/bin/gcov; ln -s /usr/bin/gcov-dump-7 /usr/bin/gcov-dump; ln -s /usr/bin/gcov-tool-7 /usr/bin/gcov-tool; ln -s /usr/bin/g++-7 /usr/bin/g++; ln -s /usr/bin/cpp-7 /usr/bin/cpp


### PR DESCRIPTION
See https://github.com/wkhtmltopdf/packaging/issues/63
This refers to gcc-7 explicitly in Ubuntu 20.04 since gcc-9 is the default and wkhtmltopdf won't compile with it.