### PR TITLE
README.md: Fix typo -- differnt => different

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Porting
 It's best if you can get the distribution/OS to support wkhtmltopdf with
 patched Qt, as it would enable using the native package management tools.
 
-Failing this, please open an issue for adding support for a differnt target.
+Failing this, please open an issue for adding support for a different target.
 In case your target also requires patches to Qt, make sure to submit and get
 them merged before opening a PR for packaging the target.
 


### PR DESCRIPTION
The README documentation seems pretty clear at this point. I just found one small typo. This PR fixes that typo. Take it or leave it as you see fit.