### PR TITLE
Support Ubuntu 22.04 Jammy Jellyfish

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -132,6 +132,30 @@ docker-targets:
       xfonts-base
       zlib1g
 
+  jammy:
+    source: docker/Dockerfile.jammy
+    args:
+      from: ubuntu:jammy
+      jpeg: libjpeg-turbo8-dev
+    output: deb
+    matrix: ['amd64', 'arm64', 'armhf', 'ppc64el']
+    depend: >
+      ca-certificates
+      fontconfig
+      libc6
+      libfreetype6
+      libjpeg-turbo8
+      libpng16-16
+      libssl3
+      libstdc++6
+      libx11-6
+      libxcb1
+      libxext6
+      libxrender1
+      xfonts-75dpi
+      xfonts-base
+      zlib1g
+
   bionic:
     source: docker/Dockerfile.debian
     args:

--- a/docker/Dockerfile.jammy
+++ b/docker/Dockerfile.jammy
@@ -1,0 +1,26 @@
+ARG  from
+FROM ${from}
+
+ARG  jpeg=libjpeg-dev
+ARG  ssl=libssl-dev
+ENV  CFLAGS=-w CXXFLAGS=-w
+
+RUN apt-get update && apt-get install -y -q --no-install-recommends \
+    dpkg-dev \
+    libc6-dev \
+    make \
+    gcc-9 \
+    g++-9 \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    $jpeg \
+    libpng-dev \
+    $ssl \
+    libx11-dev \
+    libxext-dev \
+    libxrender-dev \
+    python3 \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 10 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/cpp cpp /usr/bin/cpp-9


### PR DESCRIPTION
The new Ubuntu LTS 22.04 was released on 21 April 2022, this small patch enables support for it.