### PR TITLE
Support RHEL9-based OSes

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -22,6 +22,8 @@ jobs:
         target: focal-amd64
       bionic_amd64:
         target: bionic-amd64
+      almalinux9_x86_64:
+        target: almalinux9-x86_64
       centos8_x86_64:
         target: centos8-x86_64
       centos7_x86_64:
@@ -56,6 +58,8 @@ jobs:
         target: centos7-aarch64
       centos8_aarch64:
         target: centos8-aarch64
+      almalinux9_aarch64:
+        target: almalinux9-aarch64
       focal_arm64:
         target: focal-arm64
       opensuse_leap15_aarch64:
@@ -72,6 +76,8 @@ jobs:
         target: centos7-ppc64le
       centos8_ppc64le:
         target: centos8-ppc64le
+      almalinux9_ppc64le:
+        target: almalinux9-ppc64le
       focal_ppc64el:
         target: focal-ppc64el
       opensuse_leap15_ppc64le:

--- a/build.yml
+++ b/build.yml
@@ -180,6 +180,28 @@ docker-targets:
       xfonts-base
       zlib1g
 
+  almalinux9:
+    source: docker/Dockerfile.almalinux
+    args:
+      from: almalinux:9
+    output: rpm
+    matrix: ['x86_64', 'aarch64', 'ppc64le']
+    depend: >
+      ca-certificates
+      fontconfig
+      freetype
+      glibc
+      libjpeg
+      libpng
+      libstdc++
+      libX11
+      libXext
+      libXrender
+      openssl
+      xorg-x11-fonts-75dpi
+      xorg-x11-fonts-Type1
+      zlib
+
   centos8:
     source: docker/Dockerfile.centos
     args:

--- a/docker/Dockerfile.almalinux
+++ b/docker/Dockerfile.almalinux
@@ -1,0 +1,22 @@
+ARG  from
+FROM ${from}
+
+ENV CFLAGS=-w CXXFLAGS=-w
+
+RUN dnf install -y \
+    gzip \
+    diffutils \
+    fontconfig-devel \
+    freetype-devel \
+    gcc \
+    gcc-c++ \
+    libX11-devel \
+    libXext-devel \
+    libXrender-devel \
+    libjpeg-devel \
+    libpng-devel \
+    make \
+    openssl-devel \
+    perl \
+    zlib-devel \
+    && dnf clean all


### PR DESCRIPTION
Since CentOS 8 was EOL'd at the end of 2021 we should replace the image with `almalinux:8` or `rockylinux:8`. I chose the former because they already have released version 9, which builds up on RHEL 9. This release is using GCC 11, so we probably need to wait until the https://github.com/wkhtmltopdf/qt/commit/bb81921302fec10702d0d864d8d440fa0fe91900 patch is released.

Fixes #119