### PR TITLE
Replace CentOS 8 with AlmaLinux 8

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -22,8 +22,8 @@ jobs:
         target: focal-amd64
       bionic_amd64:
         target: bionic-amd64
-      centos8_x86_64:
-        target: centos8-x86_64
+      almalinux8_x86_64:
+        target: almalinux8-x86_64
       centos7_x86_64:
         target: centos7-x86_64
       amazonlinux2_x86_64:
@@ -54,8 +54,8 @@ jobs:
         target: buster-arm64
       centos7_aarch64:
         target: centos7-aarch64
-      centos8_aarch64:
-        target: centos8-aarch64
+      almalinux8_aarch64:
+        target: almalinux8-aarch64
       focal_arm64:
         target: focal-arm64
       opensuse_leap15_aarch64:
@@ -70,8 +70,8 @@ jobs:
         target: buster-ppc64el
       centos7_ppc64le:
         target: centos7-ppc64le
-      centos8_ppc64le:
-        target: centos8-ppc64le
+      almalinux8_ppc64le:
+        target: almalinux8-ppc64le
       focal_ppc64el:
         target: focal-ppc64el
       opensuse_leap15_ppc64le:

--- a/build.yml
+++ b/build.yml
@@ -180,10 +180,10 @@ docker-targets:
       xfonts-base
       zlib1g
 
-  centos8:
+  almalinux8:
     source: docker/Dockerfile.centos
     args:
-      from: centos:8
+      from: almalinux:8
     output: rpm
     matrix: ['x86_64', 'aarch64', 'ppc64le']
     depend: >


### PR DESCRIPTION
As requested in https://github.com/wkhtmltopdf/packaging/pull/118#issuecomment-1149486727, here's a separate PR to replace CentOS 8 with AlmaLinux 8. 
CentOS 8 was [EOL'd in December 2021](https://www.centos.org/centos-linux-eol/), [AlmaLinux](https://almalinux.org/) is a direct replacement which is also compatible to RHEL 8. The existing Dockerfile can be used as it is.