### PR TITLE
[FIX] Jammy does not come in i386 architecture

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -162,7 +162,7 @@ docker-targets:
       jpeg: libjpeg-turbo8-dev
       python: python3
     output: deb
-    matrix: ['amd64', 'i386', 'arm64', 'armhf', 'ppc64el']
+    matrix: ['amd64', 'arm64', 'armhf', 'ppc64el']
     depend: >
       ca-certificates
       fontconfig


### PR DESCRIPTION
See https://github.com/wkhtmltopdf/packaging/runs/7022309057?check_suite_focus=true#step:5:66