### PR TITLE
Adds Fedora 37 build target making use of existing Dockerfile.centos

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -26,6 +26,8 @@ jobs:
         target: almalinux8-x86_64
       centos7_x86_64:
         target: centos7-x86_64
+      fedora37_x86_64:
+        target: fedora37-x86_64
       amazonlinux2_x86_64:
         target: amazonlinux2-x86_64
       amazonlinux2_lambda:
@@ -54,6 +56,8 @@ jobs:
         target: buster-arm64
       centos7_aarch64:
         target: centos7-aarch64
+      fedora37_aarch64:
+        target: fedora37-aarch64
       almalinux8_aarch64:
         target: almalinux8-aarch64
       focal_arm64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
           - bullseye-arm64
           - bullseye-i386
           - bullseye-ppc64el
+          - fedora37-aarch64
+          - fedora37-x86_64
           - focal-ppc64el
           - jammy-amd64
           - jammy-arm64

--- a/build.yml
+++ b/build.yml
@@ -247,6 +247,28 @@ docker-targets:
       xorg-x11-fonts-Type1
       zlib
 
+  fedora37:
+    source: docker/Dockerfile.centos
+    args:
+      from: fedora:37
+    output: rpm
+    matrix: ['x86_64', 'aarch64', 'ppc64le']
+    depend: >
+      ca-certificates
+      fontconfig
+      freetype
+      glibc
+      libjpeg
+      libpng
+      libstdc++
+      libX11
+      libXext
+      libXrender
+      openssl
+      xorg-x11-fonts-75dpi
+      xorg-x11-fonts-Type1
+      zlib
+
   archlinux:
     source: docker/Dockerfile.archlinux
     args:


### PR DESCRIPTION
This is an amended version of my previous PR https://github.com/wkhtmltopdf/packaging/pull/135

With these changes, it is possible to build wkhtmltopdf for Fedora 37. There are no extra dependencies required compared to CentOS 7 so it uses the the existing Dockerfile.centos