### PR TITLE
Add Ubuntu jammy s390x architecture support

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -115,7 +115,7 @@ docker-targets:
       jpeg: libjpeg-turbo8-dev
       python: python3
     output: deb
-    matrix: ['amd64', 'arm64', 'armhf', 'ppc64el']
+    matrix: ['amd64', 'arm64', 'armhf', 'ppc64el', 's390x']
     depend: >
       ca-certificates
       fontconfig
@@ -543,6 +543,7 @@ matrix-platforms:
   armhf:   linux/arm/v7
   arm64:   linux/arm64/v8
   ppc64el: linux/ppc64le
+  s390x:   linux/s390x
   # centos
   x86_64:  linux/amd64
   i686:    linux/386


### PR DESCRIPTION
**Modified build.yml to add support for s390x architecture.**
#145 

If you want to compile wkhtmltox on your s390x architecture machine, you can follow these steps:

1. Use `git clone -b master <URL-TO-GIT>` (or specify another branch you want) to clone packaging, wkhtmltopdf, and qt repositories separately, and then copy the files in the qt directory to the qt directory in the wkhtmltopdf directory.
2. Install the relevant software packages using apt according to the README.md file in the official packaging directory (if you don't need cross-compilation, virtualbox can be skipped, and python-yaml can be installed via pip).
3. Go to https://github.com/docker/buildx/releases, download the buildx package for s390x architecture, put it in `~/.docker/cli-plugins/docker-buildx`, and give it execute permission.
4. Run `docker run --privileged --rm tonistiigi/binfmt --install all` to pull the required docker images, and then run `docker pull ruby:2.7-slim-bullseye` to pull the ruby docker image.
5. Go to the packaging directory, run `docker buildx build --platform=linux/s390x -t wkhtmltopdf/fpm:1.10.2-20221124 -f docker/Dockerfile.fpm docker/` to compile the wkhtmltopdf/fpm:1.10.2-2022112 image for the s390x architecture. (If it fails, you can try running the following two statements before compiling the docker image again: `export COMPOSE_DOCKER_CLI_BUILD=0` and `export DOCKER_BUILDKIT=0`)
6. Run `./build --no-qemu package-docker jammy-s390x <PATH-TO-WKHTMLTOPDF>` to start compiling wkhtmltox, which takes about 40 minutes.
7. After the compilation is completed, you can find the compiled deb file in the /packaging/targets directory.
8. Enjoy the full version of wkhtmltox!