### PR TITLE
Add build target: debian bookworm

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,6 +16,8 @@ jobs:
   strategy:
     matrix:
       # 64-bit x86
+      bookworm_amd64:
+        target: bookworm-amd64
       buster_amd64:
         target: buster-amd64
       focal_amd64:
@@ -50,6 +52,8 @@ jobs:
       # 64-bit ARM
       amazonlinux2_aarch64:
         target: amazonlinux2-aarch64
+      bookworkm_arm64:
+        target: bookworm-arm64
       bionic_arm64:
         target: bionic-arm64
       buster_arm64:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,8 +16,6 @@ jobs:
   strategy:
     matrix:
       # 64-bit x86
-      bookworm_amd64:
-        target: bookworm-amd64
       buster_amd64:
         target: buster-amd64
       focal_amd64:
@@ -52,8 +50,6 @@ jobs:
       # 64-bit ARM
       amazonlinux2_aarch64:
         target: amazonlinux2-aarch64
-      bookworkm_arm64:
-        target: bookworm-arm64
       bionic_arm64:
         target: bionic-arm64
       buster_arm64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           - almalinux9-ppc64le
           - almalinux9-x86_64
           - bionic-ppc64el
+          - bookworm-amd64
+          - bookworm-arm64
           - buster-ppc64el
           - bullseye-amd64
           - bullseye-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           - bionic-ppc64el
           - bookworm-amd64
           - bookworm-arm64
+          - bookworm-i386
+          - bookworm-ppc64el
           - buster-ppc64el
           - bullseye-amd64
           - bullseye-arm64
@@ -39,6 +41,7 @@ jobs:
           - jammy-amd64
           - jammy-arm64
           - jammy-ppc64el
+          - raspberrypi.bookworm-armhf
           - raspberrypi.bullseye-armhf
       fail-fast: false
     steps:

--- a/build.yml
+++ b/build.yml
@@ -66,7 +66,7 @@ docker-targets:
       from: debian:bookworm
       python: python3
     output: deb
-    matrix: ['amd64', 'arm64']
+    matrix: ['amd64', 'i386', 'arm64', 'armhf', 'armel', 'ppc64el']
     depend: >
       ca-certificates
       fontconfig
@@ -74,7 +74,32 @@ docker-targets:
       libfreetype6
       libjpeg62-turbo
       libpng16-16
-      libssl1.1
+      libssl3
+      libstdc++6
+      libx11-6
+      libxcb1
+      libxext6
+      libxrender1
+      xfonts-75dpi
+      xfonts-base
+      zlib1g
+
+  raspberrypi.bookworm-armhf:
+    source: docker/Dockerfile.debian
+    args:
+      from: balenalib/rpi-raspbian:bookworm
+      python: python3
+    output: deb
+    qemu:   linux/386 # see https://github.com/RPi-Distro/pi-gen/issues/271
+    arch:   armhf
+    depend: >
+      ca-certificates
+      fontconfig
+      libc6
+      libfreetype6
+      libjpeg62-turbo
+      libpng16-16
+      libssl3
       libstdc++6
       libx11-6
       libxcb1

--- a/build.yml
+++ b/build.yml
@@ -60,6 +60,30 @@ docker-targets:
       xfonts-base
       zlib1g
 
+  bookworm:
+    source: docker/Dockerfile.debian
+    args:
+      from: debian:bookworm
+      python: python3
+    output: deb
+    matrix: ['amd64', 'arm64']
+    depend: >
+      ca-certificates
+      fontconfig
+      libc6
+      libfreetype6
+      libjpeg62-turbo
+      libpng16-16
+      libssl1.1
+      libstdc++6
+      libx11-6
+      libxcb1
+      libxext6
+      libxrender1
+      xfonts-75dpi
+      xfonts-base
+      zlib1g
+
   raspberrypi.bullseye-armhf:
     source: docker/Dockerfile.debian
     args:


### PR DESCRIPTION
Add build target debian bookworm. 

The official wkhtmltopdf package does not have the QT patch and Debian bookworm RC is currently in "hard freeze" mode, as stated in this announcement: https://lists.debian.org/debian-devel-announce/2023/03/msg00004.html. 

The arm64 architecture build on my machine is successful.

```bash
{:timestamp=>"2023-04-10T12:17:43.124788+0000", :message=>"epoch in Version is set", :epoch=>"1", :level=>:warn}
{:timestamp=>"2023-04-10T12:18:48.458443+0000", :message=>"Created package", :path=>"wkhtmltox_0.12.6.1-1.bookworm_arm64.deb"}
```